### PR TITLE
feat[sidebar]: menu item headings

### DIFF
--- a/exampleSite/content/articles/primary-menu.md
+++ b/exampleSite/content/articles/primary-menu.md
@@ -14,14 +14,19 @@ The sidebar of the theme uses the `main` menu. Add all the items for your sideba
   url = '/'
   weight = 1
 [[menu.main]]
+  name = 'Content'
+  params.header = true
+  weight = 2
+[[menu.main]]
   name = 'Articles'
   url = '/articles'
   weight = 2
 ```
 
-- name → Title of the menu item
-- url → Path to navigate
-- weight → Used to decide the order of menu items
+- `name` → Title of the menu item
+- `url` → Path to navigate
+- `weight` → Used to decide the order of menu items
+- `params.header` → Display menu item as header
 
 If the link points to an external website, the external icon is already displayed.
 

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -20,7 +20,7 @@
   <ul class="list-none flex flex-col gap-1">
     {{ range .Site.Menus.main }}
     <li>
-      <a class="px-2 py-1.5 rounded-md text-sm flex items-center justify-between {{ if eq .URL $permalink }} bg-slate-800 text-white dark:bg-slate-50 dark:text-slate-800 dark:selection:bg-slate-400 {{ else }} hover:bg-slate-200 dark:hover:bg-slate-700 {{ end }}"
+      <a class="px-2 py-1.5 rounded-md text-sm flex items-center justify-between {{ if .Params.Header }} text-slate-400 {{ elif eq .URL $permalink }} bg-slate-800 text-white dark:bg-slate-50 dark:text-slate-800 dark:selection:bg-slate-400 {{ else }} hover:bg-slate-200 dark:hover:bg-slate-700 {{ end }}"
         href="{{ .URL }}" {{ if strings.HasPrefix .URL "http" }} target="_blank" rel="noopener" {{ end }}>
         <span>{{ .Name }}</span>
         {{ if strings.HasPrefix .URL "http" }}


### PR DESCRIPTION
This PR implements header-like menu entries. These headings are normal menu entries with no background and text color "text-slate-400"

![Screenshot 2022-05-09 at 13 02 17](https://user-images.githubusercontent.com/71837281/167399391-562a8369-1a69-4cc0-8c58-00bccfc35ae2.png)

For this, a menu entry must be created in which `params.header` is set to `true`.