### PR TITLE
Fix mobile responsiveness issue.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="{{ .Lang }}" itemscope itemtype="http://schema.org/WebPage">
 {{- partial "head.html" . -}}
 
-<body class="flex relative h-full min-h-screen">
+<body class="flex flex-col relative h-full min-h-screen">
   {{- partial "sidebar.html" . -}}
   <div class="flex-1">
     {{- block "main" . }}{{- end }}


### PR DESCRIPTION
Currently, the site is not mobile responsive when the article has large images. See this as an example:

![image](https://user-images.githubusercontent.com/38492137/211186252-8d3cc57c-bb07-4cba-8cae-7b53823f9ca8.png)

I've found that adding the `flex-col` class to the body tag fixes this issue. Now the site looks like this: 

![image](https://user-images.githubusercontent.com/38492137/211186284-4bbb483a-aedf-4d3e-94a1-70d9ee117a01.png)

Adding this tag does not cause any external unintended behaviors. Everything still seems to work as is.