### PR TITLE
Description and title alignment fixed

### DIFF
--- a/layouts/portfolio/list.html
+++ b/layouts/portfolio/list.html
@@ -7,6 +7,8 @@
     <a href="{{ .Permalink }}" class="inline-block">
       <h2 class="font-bold text-4xl lg:text-6xl py-1 px-3 mb-4 inline-block">{{ .Title }}</h2>
     </a>
+    <h3 class="ml-3 py-8 lg:py-0 lg:mx-2 text-2xl lg:text-5xl font-bold lg:font-medium !leading-tight content-center">
+      {{ $description }}</h3>
     <div class="space-y-2.5 grid grid-cols-1 lg:grid-cols-2 gap-2 lg:gap-4">
       {{ range $index, $page := .Data.Pages -}}
       <a class="block px-3 py-4 row-span-2" href="{{ .RelPermalink }}">
@@ -28,8 +30,7 @@
           View Project →</p>
       </a>
       {{ if and (eq $index 0) $description }}
-      <h3 class="ml-3 py-8 lg:py-0 lg:mx-2 text-2xl lg:text-5xl font-bold lg:font-medium !leading-tight content-center">
-        {{ $description }}</h3>
+      
       {{ end }}
       {{ end -}}
     </div>


### PR DESCRIPTION
Updated the placement of project descriptions in the portfolio section. The description is now positioned **right under the title**.
Here I'm adding two different screenshot links to help you understand better:

Before my fix: [Check before](https://lh3.googleusercontent.com/drive-viewer/AEYmBYRKQl5kcpXWJlOmETPErpNt3uQr0QkqPPJTB0NKzHulCQ8AzztKgeO39lorvNT_0UudLyox7xEHLdCSntczhFlz7WS5xw=s1600)
After my fix: [Check after](https://lh3.googleusercontent.com/drive-viewer/AEYmBYQdiXjpHTBFvvNgCKS_TAoWWgPIEu2BqghZWC6xtg-Dl7wwFDyAQvdwaTOYT3RRugb4HXDV5dmqetaqdGfgADI63QYY4w=s1600)